### PR TITLE
Add left navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,13 @@
 
 <body>
     <div class='background' id="background"></div>
+    <nav id="side-nav">
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="research.html">Research</a></li>
+            <li><a href="#blog-section">Blog</a></li>
+        </ul>
+    </nav>
     <div id='container'>
     <div id="header-container">
         <div>

--- a/research.html
+++ b/research.html
@@ -11,6 +11,13 @@
 
 <body>
     <div class='background' id="background"></div>
+    <nav id="side-nav">
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="research.html">Research</a></li>
+            <li><a href="#blog-section">Blog</a></li>
+        </ul>
+    </nav>
     <div id='container'>
     <div id="header-container">
         <div>

--- a/style.css
+++ b/style.css
@@ -32,8 +32,9 @@ body {
 
 #container {
     max-width: 1200px;
-    width: 90%;
+    width: calc(100% - 200px);
     margin: 0 auto;
+    margin-left: 200px;
     padding: 0 1rem;
 }
 
@@ -47,6 +48,7 @@ body {
     font-weight: 600;
     color: var(--accent-color);
     margin-bottom: 1rem;
+}
 nav#main-nav {
     display:flex;
     justify-content: space-between;
@@ -60,6 +62,30 @@ nav#main-nav ul {
 }
 nav#main-nav li {
     margin:0;
+}
+#side-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 180px;
+    height: 100%;
+    padding-top: 2rem;
+    background: var(--background);
+    border-right: 1px solid var(--border-color);
+}
+#side-nav ul {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    padding: 0 1rem;
+}
+#side-nav a {
+    color: var(--accent-color);
+    text-decoration: none;
+}
+#side-nav a:hover {
+    text-decoration: underline;
 }
 #theme-toggle {
     display:flex;
@@ -263,8 +289,13 @@ a:hover {
         font-size: 2rem;
     }
 
+    #side-nav {
+        display: none;
+    }
+
     #container {
         width: 95%;
+        margin-left: auto;
     }
 
     #contact {


### PR DESCRIPTION
## Summary
- add fixed side menu for easy navigation
- adjust content container to accommodate new menu
- hide menu on smaller screens
- fix missing CSS bracket

## Testing
- `htmlhint index.html research.html` *(fails: attr-value-double-quotes warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6841bda05c0c832e9ea27dbabaa4c16e